### PR TITLE
[IMP] display field planned_hours in project_api_client. The customer can know an estimation of the time the supplier will spend an the task

### DIFF
--- a/project_api_client/i18n/fr.po
+++ b/project_api_client/i18n/fr.po
@@ -259,6 +259,11 @@ msgid "Url"
 msgstr "Url"
 
 #. module: project_api_client
+#: model:ir.model.fields,field_description:project_api_client.field_external_task_planned_hours
+msgid "Planned hours"
+msgstr "Heures prévues"
+
+#. module: project_api_client
 #: code:addons/project_api_client/models/project.py:17
 #, python-format
 msgid "What is not working:\n"

--- a/project_api_client/models/project.py
+++ b/project_api_client/models/project.py
@@ -80,6 +80,7 @@ class ExternalTask(models.Model):
     to_invoice = fields.Boolean(readonly=True)
     customer_report = fields.Html(readonly=True)
     customer_kanban_report = fields.Html(readonly=True)
+    planned_hours = fields.Float(string="Planned hours")
 
     @api.model
     def _call_odoo(self, method, params):

--- a/project_api_client/views/project_view.xml
+++ b/project_api_client/views/project_view.xml
@@ -28,6 +28,7 @@
                                 <field name="author_id" readonly="1"/>
                                 <field name="create_date" readonly="1"/>
                                 <field name="origin_url" readonly="1" widget="url" string="Url"/>
+                                <field name="planned_hours" widget="float_time" readonly="1"/>
                             </group>
                         </group>
                         <notebook>


### PR DESCRIPTION
Add field planned_hours in customer side to show estimation of time.