### PR TITLE
12.0 FIX api_client: date_deadline must date not datetime

### DIFF
--- a/project_api_client/models/project.py
+++ b/project_api_client/models/project.py
@@ -54,7 +54,7 @@ class ExternalTask(models.Model):
     priority = fields.Selection(
         [("0", "Low"), ("1", "Normal"), ("2", "High")], default="1"
     )
-    date_deadline = fields.Datetime("Date deadline", readonly=True)
+    date_deadline = fields.Date("Date deadline", readonly=True)
     author_id = fields.Many2one("res.partner", string="Author", readonly=True)
     assignee_supplier_id = fields.Many2one(
         "res.partner", string="Resp. Externe", readonly=True


### PR DESCRIPTION
like in module project_api

@bguillot ct le problème que gt montré l'autre fois (1ère fois ou je mets une date sur les taches)

v8 vu que les dates sont des chaines cela ne pose pas de problème, je pense.

Tu peux merger cela stp.

Merci