### PR TITLE
project_api: fix customer subscription

### DIFF
--- a/project_api/models/project.py
+++ b/project_api/models/project.py
@@ -160,12 +160,13 @@ class ProjectTask(models.Model):
             self.message_unsubscribe(partner_ids=partner_ids)
         return super(ProjectTask, self).write(vals)
 
-    def message_auto_subscribe(self, updated_fields, values=None):
-        super(ProjectTask, self).message_auto_subscribe(updated_fields, values=values)
-        if values.get("author_id"):
-            self.message_subscribe([values["author_id"]], force=False)
-        if values.get("assignee_customer_id"):
-            self.message_subscribe([values["assignee_customer_id"]], force=False)
+    def _message_auto_subscribe(self, updated_values, followers_existing_policy='skip'):
+        super(ProjectTask, self)._message_auto_subscribe(
+            updated_values, followers_existing_policy=followers_existing_policy)
+        if updated_values.get("author_id"):
+            self.message_subscribe([updated_values["author_id"]])
+        if updated_values.get("assignee_customer_id"):
+            self.message_subscribe([updated_values["assignee_customer_id"]])
         return True
 
     def message_get_suggested_recipients(self):


### PR DESCRIPTION
@florian-dacosta : j'ai trouvé un bon bug !
Quand un client créait un ticket ça n'envoyait plus de mail car le autosubscribe était pété.

A porter (+ test en V14)
