### PR TITLE
[16.0][MIG] project_api_client

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,10 +3,10 @@ name: tests
 on:
   pull_request:
     branches:
-      - "14.0*"
+      - "16.0*"
   push:
     branches:
-      - "14.0"
+      - "16.0"
 
 jobs:
   test:
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         server_version: ["14.0"]
-        client_version: ["16.0", "14.0", "12.0", "10.0", "8.0"]
+        client_version: ["16.0"]
     env:
       SERVER_VERSION: ${{ matrix.server_version }}
       CLIENT_VERSION: ${{ matrix.client_version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         server_version: ["14.0"]
-        client_version: ["14.0", "12.0", "10.0", "8.0"]
+        client_version: ["16.0", "14.0", "12.0", "10.0", "8.0"]
     env:
       SERVER_VERSION: ${{ matrix.server_version }}
       CLIENT_VERSION: ${{ matrix.client_version }}

--- a/project_api_client/__init__.py
+++ b/project_api_client/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from . import controllers

--- a/project_api_client/controllers/__init__.py
+++ b/project_api_client/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import discuss

--- a/project_api_client/controllers/discuss.py
+++ b/project_api_client/controllers/discuss.py
@@ -1,0 +1,15 @@
+from odoo import http
+from odoo.http import request
+from odoo.addons.mail.controllers.discuss import DiscussController
+
+class DiscussControllerSupport(DiscussController):
+
+    @http.route('/mail/thread/messages', methods=['POST'], type='json', auth='user')
+    def mail_thread_messages(self, thread_model, thread_id, max_id=None, min_id=None, limit=30, **kwargs):
+        if thread_model == "external.task":
+            return request.env['mail.message']._message_fetch(domain=[
+                ('res_id', '=', int(thread_id)),
+                ('model', '=', thread_model),
+                ('message_type', '!=', 'user_notification'),
+            ], max_id=max_id, min_id=min_id, limit=limit)
+        return super().mail_thread_messages(thread_model, thread_id, max_id=max_id, min_id=min_id, limit=limit, **kwargs)

--- a/project_api_client/models/action.py
+++ b/project_api_client/models/action.py
@@ -13,9 +13,12 @@ class IrActions(models.Model):
     @api.model
     def get_bindings(self, model_name):
         """ Add an action to all Model objects of the ERP """
-        res = super(IrActions, self).get_bindings(model_name)
+        res = super().get_bindings(model_name)
         if self.env.user.has_group("project_api_client.group_support_user"):
             xml_id = "project_api_client.action_helpdesk"
-            if xml_id not in [act.get("xml_id") for act in res["action"]]:
+            support_action_id = self.env.ref(xml_id).id
+            if "action" not in res:
+                res["action"] = []
+            if support_action_id not in [act.get("id") for act in res["action"]]:
                 res["action"].append(self.env.ref(xml_id).sudo().read()[0])
         return res

--- a/project_api_client/models/project.py
+++ b/project_api_client/models/project.py
@@ -99,6 +99,9 @@ class ExternalTask(models.Model):
         if not vals.get("model_reference", False):
             vals["model_reference"] = ""
         self._add_assignee_customer(vals, vals.pop("assignee_customer_id", None))
+        # avoid returning False in description because webservice expects a string
+        if "description" in vals and not vals["description"]:
+            vals["description"] = ""
         task_id = self._call_odoo("create", vals)
         return self.browse(task_id)
 

--- a/project_api_client/models/project.py
+++ b/project_api_client/models/project.py
@@ -326,12 +326,13 @@ class IrActionActWindows(models.Model):
         ctx = self._context
 
         def get_previous_action(model):
+            # FIXME Not sure when/if this params exist some times nor in which case.
             previous_action = ctx.get("params") and ctx["params"].get("action")
-            if not previous_action:
-                act = self.env["ir.actions.act_window"].search(
-                    [("res_model", "=", model), ("view_mode", "ilike", "form")], limit=1
-                )
-                previous_action = act.id or False
+            # We avoid searching an action by default because it could contain
+            # some context making the url to fail. Example, a sale.order action
+            # which has this context : 'search_default_team_id': [active_id]
+            # would fail because the active_id we pass is actually the one from
+            # a sale order...
             return previous_action
 
         context = {"default_origin_db": self._cr.dbname}

--- a/project_api_client/views/project_view.xml
+++ b/project_api_client/views/project_view.xml
@@ -147,28 +147,6 @@
             </field>
         </record>
 
-        <record id="view_external_task_manager_form" model="ir.ui.view">
-            <field name="model">external.task</field>
-            <field name="inherit_id" ref="view_external_task_form" />
-            <field name="arch" type="xml">
-                <field name="priority" position="attributes">
-                    <attribute name="readonly">0</attribute>
-                </field>
-                <field name="tag_ids" position="attributes">
-                    <attribute name="readonly">0</attribute>
-                </field>
-                <field name="project_id" position="attributes">
-                    <attribute name="readonly">0</attribute>
-                </field>
-                <field name="assignee_customer_id" position="attributes">
-                    <attribute name="readonly">0</attribute>
-                </field>
-                <group name="project" position="attributes">
-                    <attribute name="attrs" />
-                </group>
-            </field>
-        </record>
-
         <record id="view_external_task_tree" model="ir.ui.view">
             <field name="model">external.task</field>
             <field name="arch" type="xml">

--- a/project_api_client/views/project_view.xml
+++ b/project_api_client/views/project_view.xml
@@ -58,7 +58,7 @@
                                 colspan="4"
                             />
                                 <group string="Attachments" colspan="4">
-                                    <field name="attachment_ids" nolabel="1">
+                                    <field name="attachment_ids" nolabel="1" colspan="2">
                                         <tree>
                                             <field name="name" />
                                             <field
@@ -150,10 +150,6 @@
         <record id="view_external_task_manager_form" model="ir.ui.view">
             <field name="model">external.task</field>
             <field name="inherit_id" ref="view_external_task_form" />
-            <field
-            name="groups_id"
-            eval="[(4, ref('project_api_client.group_support_manager'))]"
-        />
             <field name="arch" type="xml">
                 <field name="priority" position="attributes">
                     <attribute name="readonly">0</attribute>


### PR DESCRIPTION
@bealdav @sebastienbeau 

J'ai essayé de me pencher un peu sur le sujet, voici une première version de la migration.
Quelques points : 
1) Maintenant qu'on ne peut plus mettre de groupe au niveau des vues, est-ce qu'il y a un moyen simple de mettre un champs en readonly ou pas selon un groupe ? 
J'ai pas en tête de solution simple pour migrer cela : https://github.com/akretion/support/blob/14.0/project_api_client/views/project_view.xml#L150
Une possibilité pas ouf serait d'ajouter un champs, du genre "is_manager" sur les external task, et de le remplir dans la surcharge du read dans le cas où le user est manager, pis de mettre les champs en readonly selon un domaine contenant ce champs "is_manager". Mais je me dis qu'il doit y avoir plus simple ?

2) @sebastienbeau J'ai découvert un peu plus la gestion des mails et ça me semble quand même chaud/moyen de maintenir cela sur le long terme, car on détourne vraiment tout le système. Déjà le fait d'avoir le chatter sans hérité de mail.thread a un certain nombre d'effet de bord. Il y a peut être plus propre que ce que j'ai fait en tout cas, j'ai juste réglé les soucis que je rencontrais au plus simple sans trop me poser de question.

3) @bealdav Est-ce que c'est uniquement cette gestion des mails/messages qui te posait problème où il y avait d'autres choses ?
J'ai pas fais plus de tests que ça, et il y a peut être encore des soucis dans le module, je ne sais pas.