### PR TITLE
[14.0][FIX] project_api : Also filter projects in config and in task read group depending on customer_display field

### DIFF
--- a/project_api/services/connection.py
+++ b/project_api/services/connection.py
@@ -21,10 +21,12 @@ class ConnectionService(Component):
 
     def config(self):
         config = {"projects": []}
-        projects = self.partner.help_desk_project_id
-        for project in self.env["project.project"].search([
-            ("partner_id", "=", self.partner.id),
-            ]):
+        for project in self.env["project.project"].search(
+            [
+                ("partner_id", "=", self.partner.id),
+                ("customer_display", "=", True),
+            ]
+        ):
             config["projects"].append({
                 "id": project.id,
                 "name": project.name,

--- a/project_api/services/task.py
+++ b/project_api/services/task.py
@@ -137,7 +137,10 @@ class ExternalTaskService(Component):
     def read_group(
         self, domain, fields, groupby, offset=0, limit=None, orderby=False, lazy=True
     ):
-        domain = [("project_id.partner_id", "=", self.partner.id)] + domain
+        domain = [
+            ("project_id.partner_id", "=", self.partner.id),
+            ("project_id.customer_display", "=", True),
+        ] + domain
         task_obj = self.env["project.task"]
         group_by_stage_name = "stage_name" in groupby[0]
         if group_by_stage_name or "stage_id" in groupby[0]:


### PR DESCRIPTION
@florian-dacosta  Also filter projects in config depending on customer_display field as filtered in the task endpoint.
Maybe some refactor should be done there to have only one function listing the projects ?

EDIT : i saw your comments on the MIG 16 PR, this answers what i say above ;-)
EDIT :  Also filter projects when reading task group depending on customer_display field otherwise it is confusing client side when grouping (by stage for instance)