### PR TITLE
[IMP] Allow manager to export current view in excel

### DIFF
--- a/project_customer_access/__manifest__.py
+++ b/project_customer_access/__manifest__.py
@@ -19,6 +19,11 @@
         # https://github.com/OCA/server-auth
         "cross_connect_server",
     ],
+    "assets": {
+        "web.assets_backend": [
+            "project_customer_access/static/src/js/export_all_patch.esm.js",
+        ],
+    },
     "data": [
         "data/res_groups.xml",
         "security/ir.model.access.csv",

--- a/project_customer_access/models/project.py
+++ b/project_customer_access/models/project.py
@@ -171,3 +171,11 @@ class ProjectTask(models.Model):
             self.env = self.sudo().env
 
         return super().write(values)
+
+    def export_data(self, fields_to_export):
+        # Allow manager to export the list view to excel
+        # TODO we couuld add a check on the fields_to_export list to check there are
+        # no critical field
+        if self.env.user.has_group("project_customer_access.group_manager"):
+            return super(ProjectTask, self.sudo()).export_data(fields_to_export)
+        return super().export_data(fields_to_export)

--- a/project_customer_access/static/src/js/export_all_patch.esm.js
+++ b/project_customer_access/static/src/js/export_all_patch.esm.js
@@ -1,0 +1,16 @@
+import {registry} from "@web/core/registry";
+import {user} from "@web/core/user";
+
+const cogMenuRegistry = registry.category("cogMenu");
+
+const exportAllItem = cogMenuRegistry.get("export-all-menu");
+
+const originalIsDisplayed = exportAllItem.isDisplayed;
+
+exportAllItem.isDisplayed = async (env) => {
+    const baseCondition = await originalIsDisplayed(env);
+    const hasMyCustomGroup = await user.hasGroup(
+        "project_customer_access.group_manager"
+    );
+    return baseCondition || hasMyCustomGroup;
+};


### PR DESCRIPTION
We do not give export group access  to avoid them to access all fields, those  they do not have in view included

Code overriden : 
https://github.com/odoo/odoo/blob/18.0/addons/web/static/src/views/list/export_all/export_all.js#L34
https://github.com/odoo/odoo/blob/18.0/odoo/models.py#L1273